### PR TITLE
Fix : Inversion des actions (Set) inopérante sur les RangeController …

### DIFF
--- a/core/class/ash_RangeController.class.php
+++ b/core/class/ash_RangeController.class.php
@@ -159,8 +159,8 @@ class ash_RangeController {
 				$cmd->execCmd(array('slider' => $cmdState->execCmd() + $value));
 			}
 			case 'SetRangeValue':
-			if($_device->getOptions('OpenClose::invertSet',0) == 1){
-				$execution['payload']['rangeValue'] = 100 - $execution['payload']['rangeValue'];
+			if($_device->getOptions('RangeController::invertSet',0) == 1){
+				$_directive['payload']['rangeValue'] = 100 - $_directive['payload']['rangeValue'];
 			}
 			if (isset($_directive['endpoint']['cookie']['RangeController_setSlider'])) {
 				$cmd = cmd::byId($_directive['endpoint']['cookie']['RangeController_setSlider']);


### PR DESCRIPTION
Bonjour,

Cette PR corrige un bug empêchant l'inversion d'action de fonctionner correctement pour les équipements de type volets/stores utilisant l'interface `Alexa.RangeController`.

**Problème rencontré :**
Lorsqu'un utilisateur cochait la case "Inverser l'action" dans la configuration avancée du plugin Ash pour un volet, l'inversion de la valeur envoyée par Alexa n'était pas appliquée, ce qui entraînait un comportement inversé (les commandes vocales "Ouvre" et "Ferme" s'exécutaient à l'envers).

**Analyse :**
Dans la méthode `exec()` de la classe `ash_RangeController`, lors de la réception d'une directive `SetRangeValue` :
1. Le code vérifiait l'option avec la mauvaise clé : `OpenClose::invertSet` au lieu de `RangeController::invertSet` (qui est celle définie dans le frontend via `getHtmlConfiguration`).
2. Le calcul d'inversion était appliqué à une variable `$execution` inexistante dans le scope de la fonction, au lieu de modifier directement le payload de la directive `$_directive`.

Testé et validé sur une installation locale avec des volets Velux.

Merci pour le travail sur ce plugin !

**Correction apportée :**
Modification des lignes 162 à 168 pour cibler la bonne option de configuration et appliquer le calcul sur la bonne variable :
```php
			if($_device->getOptions('RangeController::invertSet',0) == 1){
				$_directive['payload']['rangeValue'] = 100 - $_directive['payload']['rangeValue'];
			}


