### PR TITLE
Feat: Ajout du support natif pour les portes de garage (GarageDoorController)

### DIFF
--- a/core/class/ash.class.php
+++ b/core/class/ash.class.php
@@ -36,6 +36,7 @@ include_file('core', 'ash_PercentageController', 'class', 'ash');
 include_file('core', 'ash_PowerLevelController', 'class', 'ash');
 include_file('core', 'ash_ToggleController', 'class', 'ash');
 include_file('core', 'ash_LockController', 'class', 'ash');
+include_file('core', 'ash_GarageDoorController', 'class', 'ash');
 
 class ash extends eqLogic {
 
@@ -68,7 +69,7 @@ class ash extends eqLogic {
 			'DOOR' => array('name' => __('Porte', __FILE__), 'skills' => array('ContactSensor', 'LockController')),
 			'EXTERIOR_BLIND' => array('name' => __('Volet', __FILE__), 'skills' => array('RangeController')),
 			'FAN' => array('name' => __('Ventilateur', __FILE__), 'skills' => array('PowerController', 'RangeController')),
-			'GARAGE_DOOR' => array('name' => __('Porte de garage', __FILE__), 'skills' => array('ContactSensor')),
+			'GARAGE_DOOR' => array('name' => __('Porte de garage', __FILE__), 'skills' => array('ContactSensor', 'GarageDoorController')),
 			'MICROWAVE' => array('name' => __('Micro-onde', __FILE__), 'skills' => array('PowerController')),
 			'NETWORK_HARDWARE' => array('name' => __('Equipement réseaux', __FILE__), 'skills' => array('PowerController')),
 			'PRINTER' => array('name' => __('Imprimante', __FILE__), 'skills' => array('PowerController')),

--- a/core/class/ash_GarageDoorController.class.php
+++ b/core/class/ash_GarageDoorController.class.php
@@ -1,0 +1,129 @@
+<?php
+require_once dirname(__FILE__) . '/../../../../core/php/core.inc.php';
+
+class ash_GarageDoorController {
+
+	private static $_OPEN = array('GB_OPEN', 'GARAGE_OPEN');
+	private static $_CLOSE = array('GB_CLOSE', 'GARAGE_CLOSE');
+	private static $_STATE = array('GARAGE_STATE', 'BARRIER_STATE');
+
+	public static function discover($_device, $_eqLogic) {
+		$return = array();
+		$return['capabilities'] = array();
+
+		$return['capabilities']['Alexa.GarageDoorController'] = array (
+			'type' => 'AlexaInterface',
+			'interface' => 'Alexa.ModeController',
+			'instance' => 'GarageDoor.Position',
+			'version' => '3',
+			'properties' => array (
+				'supported' => array(array('name' => 'mode')),
+				'proactivelyReported' => false,
+				'retrievable' => false,
+			),
+			'capabilityResources' => array (
+				'friendlyNames' => array(
+					array('@type' => 'asset', 'value' => array ('assetId' => 'Alexa.Setting.Opening'))
+				),
+			),
+			'configuration' => array (
+				'ordered' => false,
+				'supportedModes' => array (
+					array(
+						'value' => 'Position.Up',
+						'modeResources' => array('friendlyNames' => array(array('@type' => 'asset', 'value' => array('assetId' => 'Alexa.Value.Open'))))
+					),
+					array(
+						'value' => 'Position.Down',
+						'modeResources' => array('friendlyNames' => array(array('@type' => 'asset', 'value' => array('assetId' => 'Alexa.Value.Close'))))
+					)
+				)
+			),
+			'semantics' => array (
+				'actionMappings' => array (
+					array (
+						'@type' => 'ActionsToDirective',
+						'actions' => array ('Alexa.Actions.Open', 'Alexa.Actions.Raise'),
+						'directive' => array ('name' => 'SetMode', 'payload' => array ('mode' => 'Position.Up'))
+					),
+					array (
+						'@type' => 'ActionsToDirective',
+						'actions' => array ('Alexa.Actions.Close', 'Alexa.Actions.Lower'),
+						'directive' => array ('name' => 'SetMode', 'payload' => array ('mode' => 'Position.Down'))
+					),
+				),
+				'stateMappings' => array (
+					array ('@type' => 'StatesToValue', 'states' => array ('Alexa.States.Open'), 'value' => 'Position.Up'),
+					array ('@type' => 'StatesToValue', 'states' => array ('Alexa.States.Closed'), 'value' => 'Position.Down'),
+				),
+			),
+		);
+
+		foreach ($_eqLogic->getCmd() as $cmd) {
+			if (in_array($cmd->getGeneric_type(), self::$_OPEN)) {
+				$return['cookie']['GarageDoorController_setOpen'] = $cmd->getId();
+			}
+			if (in_array($cmd->getGeneric_type(), self::$_CLOSE)) {
+				$return['cookie']['GarageDoorController_setClose'] = $cmd->getId();
+			}
+			if (in_array($cmd->getGeneric_type(), self::$_STATE)) {
+				$return['capabilities']['Alexa.GarageDoorController']['properties']['retrievable'] = true;
+				$return['cookie']['GarageDoorController_getState'] = $cmd->getId();
+			}
+		}
+
+		if (!isset($return['cookie']['GarageDoorController_setOpen']) || !isset($return['cookie']['GarageDoorController_setClose'])) {
+			return array();
+		}
+
+		return $return;
+	}
+
+	public static function needGenericType(){
+		return array(
+			__('Ouvrir',__FILE__) => self::$_OPEN,
+			__('Fermer',__FILE__) => self::$_CLOSE,
+			__('Etat',__FILE__) => self::$_STATE
+		);
+	}
+
+	public static function exec($_device, $_directive) {
+		if ($_directive['header']['name'] == 'SetMode') {
+			$mode = $_directive['payload']['mode'];
+			if ($mode == 'Position.Up' && isset($_directive['endpoint']['cookie']['GarageDoorController_setOpen'])) {
+				$cmd = cmd::byId($_directive['endpoint']['cookie']['GarageDoorController_setOpen']);
+				if (is_object($cmd)) $cmd->execCmd();
+			} else if ($mode == 'Position.Down' && isset($_directive['endpoint']['cookie']['GarageDoorController_setClose'])) {
+				$cmd = cmd::byId($_directive['endpoint']['cookie']['GarageDoorController_setClose']);
+				if (is_object($cmd)) $cmd->execCmd();
+			}
+		}
+		return self::getState($_device, $_directive);
+	}
+
+	public static function getState($_device, $_directive) {
+		$return = array();
+		$cmd = null;
+		if (isset($_directive['endpoint']['cookie']['GarageDoorController_getState'])) {
+			$cmd = cmd::byId($_directive['endpoint']['cookie']['GarageDoorController_getState']);
+		}
+		if (!is_object($cmd)) return $return;
+
+		$value = $cmd->execCmd();
+		if ($cmd->getSubtype() == 'binary' && $cmd->getDisplay('invertBinary') == 1) {
+			$value = ($value) ? 0 : 1;
+		}
+
+		$modeValue = ($value) ? 'Position.Up' : 'Position.Down';
+
+		$return[] = array(
+			'namespace' => 'Alexa.ModeController',
+			'instance' => 'GarageDoor.Position',
+			'name' => 'mode',
+			'value' => $modeValue,
+			'timeOfSample' => date('Y-m-d\TH:i:s\Z', strtotime($cmd->getValueDate())),
+			'uncertaintyInMilliseconds' => 0,
+		);
+		return array('properties' => $return);
+	}
+}


### PR DESCRIPTION
Description
Objectif de la PR :
Ajouter le support natif des actions vocales (Ouverture / Fermeture) pour les équipements de la catégorie GARAGE_DOOR via Amazon Alexa.

Problème résolu :
Actuellement, la catégorie GARAGE_DOOR dans le plugin ASH ne supporte que la compétence ContactSensor (remontée d'état ouvert/fermé). Il est donc impossible pour un utilisateur d'ouvrir ou de fermer sa porte de garage à la voix nativement. Pour contourner cette limitation, les utilisateurs sont obligés de tricher en déclarant leur porte de garage comme un volet (EXTERIOR_BLIND).

Détail des changements et choix techniques :
Pour rester strictement conforme à la documentation de l'API Amazon Smart Home Skill, cette PR implémente le contrôle de la porte de garage via l'interface Alexa.ModeController (Instance : GarageDoor.Position).

Création de ash_GarageDoorController.class.php :

Ajout des sémantiques Position.Up (pour ouvrir) et Position.Down (pour fermer).

Mapping des actions vocales Alexa (Alexa.Actions.Open, Alexa.Actions.Close, Alexa.Actions.Raise, Alexa.Actions.Lower) vers les commandes Jeedom.

Types génériques supportés pour l'action : GB_OPEN, GARAGE_OPEN, GB_CLOSE, GARAGE_CLOSE.

Types génériques supportés pour l'état : GARAGE_STATE, BARRIER_STATE.

L'interface n'est générée que si le plugin détecte à la fois une commande d'ouverture et une commande de fermeture, évitant ainsi la création d'un contrôleur inopérant si l'utilisateur n'a qu'un capteur d'état.

Prise en charge native de l'option invertBinary sur le retour d'état.

Modification de ash.class.php :

Inclusion de la nouvelle classe ash_GarageDoorController.class.php.

Ajout de GarageDoorController dans le tableau des skills supportés par GARAGE_DOOR.


## Types of changes
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

