### PR TITLE
fix alexa with a new messageId and add delay on some answers

### DIFF
--- a/core/class/ash.class.php
+++ b/core/class/ash.class.php
@@ -204,6 +204,7 @@ class ash extends eqLogic {
 		if (isset($return['event']['endpoint']['cookie'])) {
 			unset($return['event']['endpoint']['cookie']);
 		}
+		$return['event']['header']['messageId'] = vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex(random_bytes(16)), 4));
 		return $return;
 	}
 

--- a/core/class/ash_PowerController.class.php
+++ b/core/class/ash_PowerController.class.php
@@ -117,6 +117,7 @@ class ash_PowerController {
       }
       break;
     }
+    usleep(500000);
     return self::getState($_device, $_directive);
   }
   


### PR DESCRIPTION
## Description
ash plugin currently reuse messageId on replies which seems to be forbidden by Alexa API. It has to be unique whatever the direction.
moreover when actions takes some seconds the real status is not correctly reported to alexa so I introduced a sleep of 0.5 seconds which seems to be enough

### Suggested changelog entry
fix unstable alexa answers (from jeedom to alexa)

### Related issues/external references
https://community.jeedom.com/t/alexa-ash-problemes-aleatoires/146129/

## Types of changes
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.